### PR TITLE
Typings: Add paths and closed fields

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -19,6 +19,9 @@ export interface PointLower {
 }
 
 export default class Shape {
+    paths: Point[][];
+    closed: boolean;
+    
     constructor(paths: Point[][]);
     constructor(paths: Point[][], closed: boolean);
     constructor(paths: (Point | PointLower)[][], closed: boolean, capitalConversion: boolean, integerConversion?: boolean);


### PR DESCRIPTION
This one is for completeness. I realized that `paths` and `closed` seem to intentionally be part of the public API surface of the Shape object, so I added those.