### PR TITLE
Add the organization name to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ import Shape from 'Doodle3D/clipper-js';
 Install the library.
 
 ```
-npm install clipper-js --save
+npm install @doodle3d/clipper-js --save
 ```
 
 Include the library.


### PR DESCRIPTION
I noticed that latest versions of this library are now in your organization.

Also, you may want to call [npm deprecate](https://docs.npmjs.com/cli/deprecate) on the old non-organization versions of the library with a message encouraging new installs to use the organization name.