### PR TITLE
Fix the spelling of separateShapes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -232,7 +232,7 @@ export default class Shape {
     }
   }
 
-  seperateShapes() {
+  separateShapes() {
     const shapes = [];
 
     if (!this.closed) {


### PR DESCRIPTION
Per #10, the TS definition and index.js disagree on the spelling of the word "separate", and it is index.js which uses the incorrect English spelling.